### PR TITLE
Add additional isEmpty logic for collections.

### DIFF
--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		881A82EF21131D8D00267D2E /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881A82ED21131D0F00267D2E /* DateFormattingTests.swift */; };
 		A3F605B42136F41D005CBE3F /* FlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F605B32136F41D005CBE3F /* FlowCoordinator.swift */; };
 		D2FF92C4202BA8DE00C1A129 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FF92C3202BA8DD00C1A129 /* NSAttributedStringExtensions.swift */; };
+		F8646FD0220825680026DC0E /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8646FCF220825680026DC0E /* CollectionTests.swift */; };
 		F8CA9D63216755DC00F1AF45 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CA9D62216755DB00F1AF45 /* GradientView.swift */; };
 /* End PBXBuildFile section */
 
@@ -158,6 +159,7 @@
 		A3F605B32136F41D005CBE3F /* FlowCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlowCoordinator.swift; sourceTree = "<group>"; };
 		D253FF781F0A65610079215C /* ACKategories.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ACKategories.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2FF92C3202BA8DD00C1A129 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
+		F8646FCF220825680026DC0E /* CollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		F8CA9D62216755DB00F1AF45 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -269,6 +271,7 @@
 			children = (
 				691F28D12140843300609471 /* ArrayTests.swift */,
 				69306C762029C6EF00BBE8F0 /* ColorTests.swift */,
+				F8646FCF220825680026DC0E /* CollectionTests.swift */,
 				691F858A202A00E700DA4FAD /* ConditionalAssignmentTests.swift */,
 				69306C732029C6EF00BBE8F0 /* ControlBlocksTests.swift */,
 				881A82ED21131D0F00267D2E /* DateFormattingTests.swift */,
@@ -529,6 +532,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				69306C832029C92B00BBE8F0 /* ColorTests.swift in Sources */,
+				F8646FD0220825680026DC0E /* CollectionTests.swift in Sources */,
 				6925243520D145F600228289 /* UIStackViewTests.swift in Sources */,
 				6939359B2080A34C00EDA582 /* UIViewControllerChildrenTests.swift in Sources */,
 				691F858B202A00E700DA4FAD /* ConditionalAssignmentTests.swift in Sources */,

--- a/ACKategories/CollectionExtensions.swift
+++ b/ACKategories/CollectionExtensions.swift
@@ -22,7 +22,7 @@ extension Optional where Wrapped: Collection {
     }
 
     /// Return `self` if it is not empty and not nil, otherwise return nil
-    var nonEmpty: Wrapped? {
+    public var nonEmpty: Wrapped? {
         return self?.isEmpty == true ? nil : self
     }
 }

--- a/ACKategories/CollectionExtensions.swift
+++ b/ACKategories/CollectionExtensions.swift
@@ -10,12 +10,32 @@ extension Optional where Wrapped: Collection {
             return value.isEmpty
         }
     }
+
+    /// Return `true` if `self` is not empty and not nil
+    public var isNotEmpty: Bool {
+        switch self {
+        case .none:
+            return false
+        case .some(let value):
+            return !value.isEmpty
+        }
+    }
+
+    /// Return `self` if it is not empty and not nil, otherwise return nil
+    var nonEmpty: Wrapped? {
+        return self?.isEmpty == true ? nil : self
+    }
 }
 
 extension Collection {
     /// Return object at index if inside bounds, `nil` otherwise
     public subscript(safe index: Index) -> Iterator.Element? {
         return indices.contains(index) ? self[index] : nil
+    }
+
+    /// Return `true` if `self¨ is not empty
+    public var isNotEmpty: Bool {
+        return !isEmpty
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 ```
 - Move from NSLog to unified logging (#39, kudos to @fortmarek)
-```## master
+```
 
-## 6.0.2 
-
+```
 - Allow additional logic for isEmpty for collections (#40, kudos to @marekfort) 
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,8 @@
 
 ```
 - Move from NSLog to unified logging (#39, kudos to @fortmarek)
-```
+```## master
+
+## 6.0.2 
+
+- Allow additional logic for isEmpty for collections (#40, kudos to @marekfort) 

--- a/Tests/CollectionTests.swift
+++ b/Tests/CollectionTests.swift
@@ -1,0 +1,46 @@
+//
+//  CollectionTests.swift
+//  UnitTests
+//
+//  Created by Marek Fořt on 2/4/19.
+//  Copyright © 2019 Ackee, s.r.o. All rights reserved.
+//
+
+import XCTest
+
+class CollectionTests: XCTestCase {
+
+    func testNonEmpty() {
+        var array: [Int]? = nil
+
+        XCTAssertNil(array.nonEmpty)
+
+        array = []
+        XCTAssertNil(array.nonEmpty)
+
+        array = [1]
+        XCTAssertNotNil(array.nonEmpty)
+    }
+
+    func testIsNotEmptyOptional() {
+        var array: [Int]? = nil
+
+        XCTAssertFalse(array.isNotEmpty)
+
+        array = []
+        XCTAssertFalse(array.isNotEmpty)
+
+        array = [1]
+        XCTAssertTrue(array.isNotEmpty)
+    }
+
+    func testIsNotEmpty() {
+        var array: [Int] = []
+
+        XCTAssertFalse(array.isNotEmpty)
+
+        array = [1]
+        XCTAssertTrue(array.isNotEmpty)
+    }
+
+}


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.

This PR adds `isNotEmpty` and `nonEmpty` bools for `Collection`. Why? The reason for `isNotEmpty` is, well, because `!collection.isEmpty` is not really that readable and you have to go back to write it if you forget it at first which gets me kind of annoyed sometimes. 
As for `nonEmpty`, I think it's best if I point to the source I got it from: https://www.objc.io/blog/2019/01/22/non-empty-optionals/?utm_campaign=Indie%2BiOS%2BFocus%2BWeekly&utm_medium=email&utm_source=Indie_iOS_Focus_Weekly_205