### PR TITLE
Handling iOS 13 modal presentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.2
+osx_image: xcode11.1
 language: objective-c
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode11.1
+osx_image: xcode11.2
 language: objective-c
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 after_deploy:
 - pod trunk push
 script:
-- set -o pipefail && xcodebuild test -scheme ACKategories -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES | xcpretty
+- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.1' ONLY_ACTIVE_ARCH=YES | xcpretty
 - pod lib lint
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 after_deploy:
 - pod trunk push
 script:
-- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone XS,OS=12.2' ONLY_ACTIVE_ARCH=YES | xcpretty
+- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.1' ONLY_ACTIVE_ARCH=YES | xcpretty
 - pod lib lint
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 after_deploy:
 - pod trunk push
 script:
-- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.1' ONLY_ACTIVE_ARCH=YES | xcpretty
+- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.2' ONLY_ACTIVE_ARCH=YES | xcpretty
 - pod lib lint
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 after_deploy:
 - pod trunk push
 script:
-- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.1' ONLY_ACTIVE_ARCH=YES | xcpretty
+- set -o pipefail && xcodebuild test -scheme ACKategories -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES | xcpretty
 - pod lib lint
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_deploy:
 after_deploy:
 - pod trunk push
 script:
-- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.2' ONLY_ACTIVE_ARCH=YES | xcpretty
+- set -o pipefail && xcodebuild test -scheme ACKategories -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=13.2.2' ONLY_ACTIVE_ARCH=YES | xcpretty
 - pod lib lint
 deploy:
   provider: releases

--- a/ACKategories-Example/Flow coordinators/AppFlowCoordinator.swift
+++ b/ACKategories-Example/Flow coordinators/AppFlowCoordinator.swift
@@ -27,15 +27,19 @@ final class AppFlowCoordinator: Base.FlowCoordinatorNoDeepLink {
 
 extension AppFlowCoordinator: ExampleListFlowDelegate {
     func exampleItemSelected(_ item: ExampleItem, in viewController: ExampleListViewController) {
-        let itemVC = controller(for: item)
-        itemVC.title = item.title
-        navigationController?.pushViewController(itemVC, animated: true)
-    }
-    
-    private func controller(for item: ExampleItem) -> UIViewController {
         switch item {
-        case .uiControlBlocks: return UIControlBlocksViewController()
-        case .viewControllerComposition: return VCCompositionViewController()
+        case .uiControlBlocks:
+            let itemVC = UIControlBlocksViewController()
+            itemVC.title = item.title
+            navigationController?.pushViewController(itemVC, animated: true)
+        case .viewControllerComposition:
+            let itemVC = VCCompositionViewController()
+            itemVC.title = item.title
+            navigationController?.pushViewController(itemVC, animated: true)
+        case .present:
+            let modalFlow = ModalFlowCoordinator()
+            addChild(modalFlow)
+            modalFlow.start(from: viewController)
         }
     }
 }

--- a/ACKategories-Example/Flow coordinators/ModalFlowCoordinator.swift
+++ b/ACKategories-Example/Flow coordinators/ModalFlowCoordinator.swift
@@ -1,0 +1,28 @@
+//
+//  ModalFlowCoordinator.swift
+//  ACKategories-Example
+//
+//  Created by Jakub Olejník on 22/10/2019.
+//  Copyright © 2019 Ackee, s.r.o. All rights reserved.
+//
+
+import UIKit
+import ACKategories
+
+final class ModalFlowCoordinator: Base.FlowCoordinatorNoDeepLink {
+    override func start(from viewController: UIViewController) {
+        let modalVC = ModalViewController()
+        modalVC.flowDelegate = self
+        rootViewController = modalVC
+        
+        super.start(from: viewController)
+     
+        viewController.present(modalVC, animated: true)
+    }
+}
+
+extension ModalFlowCoordinator: ModalFlowDelegate {
+    func didTapDismiss(in viewController: ModalViewController) {
+        stop(animated: true)
+    }
+}

--- a/ACKategories-Example/Flow coordinators/ModalFlowCoordinator.swift
+++ b/ACKategories-Example/Flow coordinators/ModalFlowCoordinator.swift
@@ -11,12 +11,11 @@ import ACKategories
 
 final class ModalFlowCoordinator: Base.FlowCoordinatorNoDeepLink {
     override func start(from viewController: UIViewController) {
+        super.start(from: viewController)
+        
         let modalVC = ModalViewController()
         modalVC.flowDelegate = self
         rootViewController = modalVC
-        
-        super.start(from: viewController)
-     
         viewController.present(modalVC, animated: true)
     }
 }

--- a/ACKategories-Example/Model/ExampleItem.swift
+++ b/ACKategories-Example/Model/ExampleItem.swift
@@ -8,11 +8,10 @@
 
 import Foundation
 
-enum ExampleItem {
+enum ExampleItem: CaseIterable {
     case uiControlBlocks
     case viewControllerComposition
-    
-    static var allCases: [ExampleItem] { return [.uiControlBlocks, .viewControllerComposition] }
+    case present
     
     var title: String { return data.title }
     var subtitle: String { return data.subtitle }
@@ -21,6 +20,7 @@ enum ExampleItem {
         switch self {
         case .uiControlBlocks: return ("UIControl blocks", "Use closures instead of target - selector pattern")
         case .viewControllerComposition: return ("View controller composition", "Simply embed view controller into another one")
+        case .present: return ("Present", "Example usage of starting flow coordinator with modal present")
         }
     }
 }

--- a/ACKategories-Example/Screens/Base/BaseViewController.swift
+++ b/ACKategories-Example/Screens/Base/BaseViewController.swift
@@ -37,4 +37,9 @@ class BaseViewControllerNoVM: BaseViewController<NoViewModel> {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func loadView() {
+        super.loadView()
+        view.backgroundColor = .white
+    }
 }

--- a/ACKategories-Example/Screens/Modal/ModalViewController.swift
+++ b/ACKategories-Example/Screens/Modal/ModalViewController.swift
@@ -1,0 +1,42 @@
+//
+//  ModalViewController.swift
+//  ACKategories-Example
+//
+//  Created by Jakub Olejník on 22/10/2019.
+//  Copyright © 2019 Ackee, s.r.o. All rights reserved.
+//
+
+import UIKit
+
+protocol ModalFlowDelegate: AnyObject {
+    func didTapDismiss(in viewController: ModalViewController)
+}
+
+final class ModalViewController: BaseViewControllerNoVM {
+    weak var flowDelegate: ModalFlowDelegate?
+    
+    private weak var button: UIButton!
+    
+    // MARK: - View life cycle
+    
+    override func loadView() {
+        super.loadView()
+        
+        let button = UIButton(type: .system)
+        button.setTitle("Dismiss", for: .normal)
+        view.addSubview(button)
+        button.snp.makeConstraints { (make) in
+            make.center.equalToSuperview()
+        }
+        self.button = button
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        button.on { [weak self] _ in
+            guard let self = self else { return }
+            self.flowDelegate?.didTapDismiss(in: self)
+        }
+    }
+}

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -689,7 +689,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "ACKategories-Example/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -717,7 +717,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "ACKategories-Example/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -744,7 +744,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Tests/Supporting files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -775,7 +775,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Tests/Supporting files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		693B960E214979060036C236 /* TitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693B960D214979060036C236 /* TitleViewController.swift */; };
 		69A77B0322B3B33900AABFEF /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A77B0222B3B33900AABFEF /* UIViewExtensions.swift */; };
 		69A77B0522B3B3DD00AABFEF /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A77B0422B3B3DD00AABFEF /* UIViewTests.swift */; };
+		69C8EE23235F429800FDB01E /* ModalFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C8EE22235F429800FDB01E /* ModalFlowCoordinator.swift */; };
+		69C8EE27235F42DE00FDB01E /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C8EE26235F42DE00FDB01E /* ModalViewController.swift */; };
 		881A82EC21131CEC00267D2E /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881A82EB21131CEC00267D2E /* DateFormatting.swift */; };
 		881A82EF21131D8D00267D2E /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881A82ED21131D0F00267D2E /* DateFormattingTests.swift */; };
 		8835B8252253956C0011F003 /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835B8242253956C0011F003 /* Base.swift */; };
@@ -164,6 +166,8 @@
 		69932D312358650D00B8D195 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		69A77B0222B3B33900AABFEF /* UIViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		69A77B0422B3B3DD00AABFEF /* UIViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewTests.swift; sourceTree = "<group>"; };
+		69C8EE22235F429800FDB01E /* ModalFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalFlowCoordinator.swift; sourceTree = "<group>"; };
+		69C8EE26235F42DE00FDB01E /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		881A82EB21131CEC00267D2E /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
 		881A82ED21131D0F00267D2E /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		8835B8242253956C0011F003 /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
@@ -323,6 +327,7 @@
 			isa = PBXGroup;
 			children = (
 				693B96002149747E0036C236 /* AppFlowCoordinator.swift */,
+				69C8EE22235F429800FDB01E /* ModalFlowCoordinator.swift */,
 			);
 			path = "Flow coordinators";
 			sourceTree = "<group>";
@@ -346,10 +351,11 @@
 		693B9607214977F80036C236 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
-				888BAF3022576892009A2E78 /* BaseViewController.swift */,
-				693B960A214978930036C236 /* VC composition */,
+				69C8EE24235F42C100FDB01E /* Base */,
 				693B95FC214973000036C236 /* Example list */,
+				69C8EE25235F42CB00FDB01E /* Modal */,
 				693B96022149773F0036C236 /* UIControl blocks */,
+				693B960A214978930036C236 /* VC composition */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -361,6 +367,22 @@
 				693B960D214979060036C236 /* TitleViewController.swift */,
 			);
 			path = "VC composition";
+			sourceTree = "<group>";
+		};
+		69C8EE24235F42C100FDB01E /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				888BAF3022576892009A2E78 /* BaseViewController.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		69C8EE25235F42CB00FDB01E /* Modal */ = {
+			isa = PBXGroup;
+			children = (
+				69C8EE26235F42DE00FDB01E /* ModalViewController.swift */,
+			);
+			path = Modal;
 			sourceTree = "<group>";
 		};
 		8835B8232253955B0011F003 /* Base */ = {
@@ -550,11 +572,13 @@
 				693B95FE2149733B0036C236 /* ExampleListViewModel.swift in Sources */,
 				693B960C214978B50036C236 /* VCCompositionViewController.swift in Sources */,
 				693B95F6214970080036C236 /* ExampleListViewController.swift in Sources */,
+				69C8EE27235F42DE00FDB01E /* ModalViewController.swift in Sources */,
 				691F856B2029E2E100DA4FAD /* AppDelegate.swift in Sources */,
 				888BAF3122576892009A2E78 /* BaseViewController.swift in Sources */,
 				693B9604214977740036C236 /* UIControlBlocksViewController.swift in Sources */,
 				693B96012149747E0036C236 /* AppFlowCoordinator.swift in Sources */,
 				693B95F9214972B40036C236 /* ExampleItem.swift in Sources */,
+				69C8EE23235F429800FDB01E /* ModalFlowCoordinator.swift in Sources */,
 				693B960E214979060036C236 /* TitleViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ACKategories/Base/FlowCoordinator.swift
+++ b/ACKategories/Base/FlowCoordinator.swift
@@ -20,7 +20,12 @@ extension Base {
         public weak var navigationController: UINavigationController?
         
         /// First VC of the flow. Must be set when FC starts.
-        public weak var rootViewController: UIViewController!
+        public weak var rootViewController: UIViewController! {
+            didSet { rootVCSetter(rootViewController) }
+        }
+        
+        /// When flow coordinator handles modally presented flow, we are interested `rootVC` changes
+        private var rootVCSetter: (UIViewController?) -> () = { _ in }
         
         /// Parent coordinator
         public weak var parentCoordinator: FlowCoordinator?
@@ -55,11 +60,11 @@ extension Base {
         }
         
         /// Start by presenting from given VC. This method must be overriden by subclass.
-        ///
-        /// Make sure that `rootViewController` is set so no iOS 13 presentation leaks are possible
         open func start(from viewController: UIViewController) {
-            assert(rootViewController != nil, "rootViewController is nil")
-            rootViewController?.presentationController?.delegate = self
+            rootVCSetter = { [weak self] rootVC in
+                rootVC?.presentationController?.delegate = self
+            }
+            rootVCSetter(rootViewController)
         }
         
         /// Clean up. Must be called when FC finished the flow to avoid memory leaks and unexpcted behavior.

--- a/ACKategories/Base/FlowCoordinator.swift
+++ b/ACKategories/Base/FlowCoordinator.swift
@@ -14,7 +14,7 @@ extension Base {
      All start methods are supposed to be overriden and property `rootViewController` must be set in the end of the overriden implementation to avoid memory leaks.
      Don't forget to call super.start().
      */
-    open class FlowCoordinator<DeepLinkType>: NSObject, UINavigationControllerDelegate {
+    open class FlowCoordinator<DeepLinkType>: NSObject, UINavigationControllerDelegate, UIAdaptivePresentationControllerDelegate {
         
         /// Reference to the navigation controller used within the flow
         public weak var navigationController: UINavigationController?
@@ -55,8 +55,11 @@ extension Base {
         }
         
         /// Start by presenting from given VC. This method must be overriden by subclass.
+        ///
+        /// Make sure that `rootViewController` is set so no iOS 13 presentation leaks are possible
         open func start(from viewController: UIViewController) {
-            checkRootViewController()
+            assert(rootViewController != nil, "rootViewController is nil")
+            rootViewController?.presentationController?.delegate = self
         }
         
         /// Clean up. Must be called when FC finished the flow to avoid memory leaks and unexpcted behavior.
@@ -123,6 +126,14 @@ extension Base {
             
             if let firstViewController = rootViewController, fromViewController == firstViewController {
                 navigationController.delegate = parentCoordinator
+                stop()
+            }
+        }
+        
+        // MARK: - UIAdaptivePresentationControllerDelegate
+        
+        public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            if presentationController.presentedViewController == rootViewController {
                 stop()
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## Next
 
 - add `tapestry` for automating future releases (#56, kudos to @fortmarek)
+- update [FlowCoordinator](ACKategories/Base/FlowCoordinator.swift) to count with iOS 13 modal presentations (#55, kudos to @olejnjak)
+    
+    ⚠️ **BREAKING CHANGE:** as `FlowCoordinator.start(from viewController:)` now expects that its `rootViewController` is already set, you might need to adjust some of your code
 
 ## 6.2
 - add `forceIntrinsic()` to `UIView` to set its `contentHuggingPriority` and `contentCompressionResistance` to `UILayoutPriority.required` (#48, kudos to @olejnjak)

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SnapKit/SnapKit" "5.0.0"
+github "SnapKit/SnapKit" "5.0.1"

--- a/Documentation/FlowCoordinators.md
+++ b/Documentation/FlowCoordinators.md
@@ -1,0 +1,49 @@
+# Flow coordinators
+
+ACKategories contains a basic [FlowCoordinator][flow-coordinator-impl] which should be parent of all your flow coordinators as it is capable of handling many complicated cases for you automatically.
+
+We'll try to explain those cases in this documentation.
+
+## Basics
+
+Here we'll cover some basic of how flow coordinators should work.
+
+### Starting a flow
+
+Every flow coordinator needs to be started by some variant of `start(...)` method. If you're not starting any complicated flow, you're probably searching for basic `start()` method.
+
+If you want your flow coordinator to handle some part of navigation inside `UINavigationController` you're searching for `start(with navigationController:)` method.
+
+If you start by presenting a view controller modally, you're searching for `start(from viewController:)`.
+
+Or you can add your own `start(...)` method but make sure you call super class method which is appropriate for your use case.
+
+### Stopping a flow
+
+Well as you have previously started a flow, you should also stop it some time. Basic cases of stopping a flow are handled automatically, others you'll have to handle yourself.
+
+## ⚠️ Known limits
+
+Well start with quick summary of known limits, if you're interested in more information
+
+For handling multiple flow coordinators taking care of a single `UINavigationController` stack, we set its delegate, so you should count with that.
+
+For handling interactive dismiss on iOS 13 we set the `presentationController.delegate` and we expect the `rootViewController` to be set when calling `super.start(from: viewController)` so you should also count with that.
+
+#### Pop `rootViewController` from navigation stack
+
+If you use more flow coordinators to handle your navigation stack inside `UINavigationController` you can get into situation that somewhere in the middle of your navigation stack, you start a new flow coordinator which takes current navigation stack and pushes a new controller. Well when that previously pushed view controller is popped you should `stop` its flow coordinator as it has nothing to manage.
+
+This case is handled automatically as `FlowCoordinator` sets itself as delegate of that `UINavigationController` and observes changes to navigation stack, when coordinator's `rootViewController` is popped out of the navigation stack, it stops itself and sets its parent as new `UINavigationtionControllerDelegate`.
+
+**⚠️ KNOWN LIMITS:** If you need to set your own `UINavigationControllerDelegate`, you can, but you have to take care of those cases yourself. It might be a good idea to look at the [FlowCoordinator implementation][flow-coordinator-impl] on how this can be done.
+
+#### Interactive dismiss of iOS 13 modal view controller
+
+Since iOS 13 the `pageSheet` modal presentation is default modal presentation style. As user can by default dismiss presented modal screen by dragging it towards the bottom edge of the screen, you can no longer rely that some of your callbacks (that surely handle stopping your flow coordinator correctly 😎) will be called.
+
+When calling `start(from viewController:)` the `FlowCoordinator` sets itself as the `presentationController.delegate` and checks if the `rootViewController` has been interactively dismissed. This means that when calling `super.start(from: viewController)` the `rootViewController` needs to be already set, otherwise the observations wouldn't work.
+
+**⚠️ KNOWN LIMITS:** If you need to set your own `presentationController.delegate`, you can, but you have to take care of those cases yourself. It might be a good idea to look at the [FlowCoordinator implementation][flow-coordinator-impl] on how this can be done.
+
+[flow-coordinator-impl]: ../ACKategories/Base/FlowCoordinator.swift

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ If you're interested in using ACKategories in your older projects see all branch
 ## List of features
 This is only fast description of features, see source code for documentation comments and details.
 
+### Flow coordinators
+
+ACKategories contain basic `FlowCoordinator` that should be used as parent class for all your flow coordinators. For more information see [FlowCoordinators](Documentation/FlowCoordinators.md).
+
 ### UIButton
 Extension for UIButton that fixes `intrinsicContentSize` and adds `titleEdgeInsets` to it.
 


### PR DESCRIPTION
This PR tries to address the issue with interactive dismiss of iOS 13 modals (#54).

This PR is considered to be a work in progress and right now is not intended to be merged at first I'd love to discuss it with the rest of the team as it contains semantically breaking change in `FlowCoordinator.start(from viewController:)` as it now expects `rootViewController` to be already set, otherwise it will fail on an `assertion`.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Updated CHANGELOG.md.
- [x] Added tests (if applicable)
