### PR TITLE
♻️ Use native `searchTextField` for `UISearchBar.textField`

### DIFF
--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = "Ackee, s.r.o.";
 				TargetAttributes = {
 					691F85672029E2E100DA4FAD = {
@@ -930,7 +930,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -957,7 +957,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;

--- a/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategories.xcscheme
+++ b/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategories.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D253FF771F0A65610079215C"
+            BuildableName = "ACKategories.framework"
+            BlueprintName = "ACKategories"
+            ReferencedContainer = "container:ACKategories.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D253FF771F0A65610079215C"
-            BuildableName = "ACKategories.framework"
-            BlueprintName = "ACKategories"
-            ReferencedContainer = "container:ACKategories.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:ACKategories.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ACKategories/UISearchBarExtensions.swift
+++ b/ACKategories/UISearchBarExtensions.swift
@@ -5,6 +5,7 @@ public extension UISearchBar {
     ///
     /// On iOS 13+ this just calls `searchTextField`, and if you're targeting iOS 13+,
     /// you should use that as you get `UISearchTextField` instead of just `UITextField`.
+    @available(iOS, deprecated: 13, renamed: "searchTextField")
     var textField: UITextField! {
         if #available(iOS 13, *) {
             return searchTextField

--- a/ACKategories/UISearchBarExtensions.swift
+++ b/ACKategories/UISearchBarExtensions.swift
@@ -2,5 +2,13 @@ import UIKit
 
 public extension UISearchBar {
     /// Shorthand for contained textField
-    var textField: UITextField! { return value(forKey: "searchField") as? UITextField }
+    ///
+    /// On iOS 13+ this just calls `searchTextField`, and if you're targeting iOS 13+,
+    /// you should use that as you get `UISearchTextField` instead of just `UITextField`.
+    var textField: UITextField! {
+        if #available(iOS 13, *) {
+            return searchTextField
+        }
+        return value(forKey: "searchField") as? UITextField
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ```
 
 ## Next
+- use native `UISearchBar.searchTextField` on iOS 13+ (#61, kudos to @olejnjak)
 
 ## 6.3
 - add support for generic dequeueing for MKAnnotationViews `dequeueAnnotationView(for annotation: MKAnnotation)` (#60, kudos to @svastven)


### PR DESCRIPTION
This PR uses `UISearchbar.textField` on iOS 13+. Implements #57.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Updated CHANGELOG.md.
- [x] Added tests (if applicable)
