### PR TITLE
🔧 Generate docs only on push to master.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Documentation
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ```
 
 ## Next
+- Fix generate docs action ([#73](https://github.com/AckeeCZ/ACKategories/pull/73), kudos to @fortmarek)
 - Use a preferred `AnyObject` keyword instead of `class` in protocol conformance ([#71](https://github.com/AckeeCZ/ACKategories/pull/71), kudos to @michalsrutek)
 - Fix a typo ([#70](https://github.com/AckeeCZ/ACKategories/pull/70), kudos to @michalsrutek)
 - Fix swiftlint violations ([#69](https://github.com/AckeeCZ/ACKategories/pull/69), kudos to @fortmarek)


### PR DESCRIPTION
#### Checklist
- [x] Added tests (if applicable)

Currently docs are generated on any push to any branch. This should be changed to only push to master.