### PR TITLE
Fix changelog check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Changelog Reminder
         uses: peterjgrainger/action-changelog-reminder@v1.2.0
         with:
-          changelog_regex: '/CHANGELOG.md'
+          changelog_regex: 'CHANGELOG.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   podspec:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Changelog Reminder
-        uses: peterjgrainger/action-changelog-reminder@v1
+        uses: peterjgrainger/action-changelog-reminder@v1.2.0
+        with:
+          changelog_regex: '/CHANGELOG.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   podspec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Set `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES` ([#75](https://github.com/AckeeCZ/ACKategories/pull/75), kudos to @fortmarek)
 - Do not dismiss `presentingViewController` of `rootViewController` on `Base.FlowCoordinator` `stop()` when remaining VCs in the navigation stack ([#72](https://github.com/AckeeCZ/ACKategories/pull/72), kudos to @IgorRosocha)
 
+### Fixed
+
+- Fix changelog check ([#81](https://github.com/AckeeCZ/ACKategories/pull/72), kudos to @olejnjak)
+
 ## 6.4.1
 
 ### Fixed


### PR DESCRIPTION
Default regex for changelog check doesn't match our changelog, so the check action always thinks that changelog is missing, update of action and regex change fixes this problem.

#### Checklist
- [x] Added tests (if applicable)
