### PR TITLE
✨ Add completion block for stop function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Added
 
+- Completion block for `stop` ([#88](https://github.com/AckeeCZ/ACKategories/pull/88), kudos to @fortmarek)
 - Run SwiftLint on build if installed locally ([#87](https://github.com/AckeeCZ/ACKategories/pull/87), kudos to @olejnjak)
 - Add Catalyst support to iOS target ([#86](https://github.com/AckeeCZ/ACKategories/pull/86), kudos to @olejnjak)
 - Add UserDefault property wrapper ([#85](https://github.com/AckeeCZ/ACKategories/pull/85), kudos to @fortmarek)


### PR DESCRIPTION
#### Checklist
- [ ] Added tests (if applicable)

In some cases, it is necessary to wait for completion of animation of `stop` function.

I am not sure how exactly I can test this, so ideas in this regard are welcome 🙂 

I tried it out in one of our projects where this was causing an issue and it worked like a charm ✨ 