### PR TITLE
Bugfix/user default

### DIFF
--- a/ACKategoriesCore/PropertyWrappers/UserDefault.swift
+++ b/ACKategoriesCore/PropertyWrappers/UserDefault.swift
@@ -29,11 +29,14 @@ public struct UserDefault<Value: Codable> {
         get {
             guard let data = userDefaults.object(forKey: key) as? Data else { return defaultValue }
             let decoder = JSONDecoder()
-            return (try? decoder.decode(Value.self, from: data)) ?? defaultValue
+            // Encoding root-level `singleValueContainer` fails on iOS <= 12.0
+            // Thus we always encode it into array, so it has a root object
+            // Related issue: https://github.com/AckeeCZ/ACKategories/issues/89
+            return (try? decoder.decode([Value].self, from: data))?.first ?? defaultValue
         }
         set {
             let encoder = JSONEncoder()
-            let data = try? encoder.encode(newValue)
+            let data = try? encoder.encode([newValue])
             userDefaults.set(data, forKey: key)
         }
     }

--- a/ACKategoriesCore/PropertyWrappers/UserDefault.swift
+++ b/ACKategoriesCore/PropertyWrappers/UserDefault.swift
@@ -42,7 +42,7 @@ public struct UserDefault<Value: Codable> {
                 guard let data = userDefaults.object(forKey: key) as? Data else { return defaultValue }
                 let decoder = JSONDecoder()
                 // Encoding root-level `singleValueContainer` fails on iOS <= 12.0
-                // Thus we always encode/dcode it into array, so it has a root object
+                // Thus we always encode/decode it into array, so it has a root object
                 // Related issue: https://github.com/AckeeCZ/ACKategories/issues/89
                 do {
                     return try decoder.decode([Value].self, from: data).first ?? defaultValue

--- a/ACKategoriesCore/PropertyWrappers/UserDefault.swift
+++ b/ACKategoriesCore/PropertyWrappers/UserDefault.swift
@@ -11,33 +11,59 @@ import Foundation
 /// [Apple documentation on UserDefaults](https://developer.apple.com/documentation/foundation/userdefaults)
 @propertyWrapper
 public struct UserDefault<Value: Codable> {
-    let key: String
-    let defaultValue: Value
-    var userDefaults: UserDefaults
+    private let key: String
+    private let defaultValue: Value
+    private var userDefaults: UserDefaults
+    private let errorLogger: ((Error) -> Void)?
 
     /// - Parameters:
     ///     - key: Key for which the value should be saved
     ///     - default: Default value to be used
     ///     - userDefaults: `UserDefaults` where value should be saved into. Default is `UserDefaults.standard`
-    public init(_ key: String, `default`: Value, userDefaults: UserDefaults = .standard) {
+    ///     - errorLogger: Closure that is triggered with error from encoding/decoding values from setter/getter
+    public init(
+        _ key: String,
+        `default`: Value,
+        userDefaults: UserDefaults = .standard,
+        errorLogger: ((Error) -> Void)? = { print($0) }
+    ) {
         self.key = key
         self.defaultValue = `default`
         self.userDefaults = userDefaults
+        self.errorLogger = errorLogger
     }
 
     public var wrappedValue: Value {
         get {
-            guard let data = userDefaults.object(forKey: key) as? Data else { return defaultValue }
-            let decoder = JSONDecoder()
-            // Encoding root-level `singleValueContainer` fails on iOS <= 12.0
-            // Thus we always encode it into array, so it has a root object
-            // Related issue: https://github.com/AckeeCZ/ACKategories/issues/89
-            return (try? decoder.decode([Value].self, from: data))?.first ?? defaultValue
+            // Check if `Value` is supported by default by `UserDefaults`
+            if Value.self as? PropertyListValue.Type != nil {
+                return userDefaults.object(forKey: key) as? Value ?? defaultValue
+            } else {
+                guard let data = userDefaults.object(forKey: key) as? Data else { return defaultValue }
+                let decoder = JSONDecoder()
+                // Encoding root-level `singleValueContainer` fails on iOS <= 12.0
+                // Thus we always encode/dcode it into array, so it has a root object
+                // Related issue: https://github.com/AckeeCZ/ACKategories/issues/89
+                do {
+                    return try decoder.decode([Value].self, from: data).first ?? defaultValue
+                } catch {
+                    errorLogger?(error)
+                    return defaultValue
+                }
+            }
         }
         set {
-            let encoder = JSONEncoder()
-            let data = try? encoder.encode([newValue])
-            userDefaults.set(data, forKey: key)
+            if Value.self as? PropertyListValue.Type != nil {
+                userDefaults.set(newValue, forKey: key)
+            } else {
+                let encoder = JSONEncoder()
+                do {
+                    let data = try encoder.encode([newValue])
+                    userDefaults.set(data, forKey: key)
+                } catch {
+                    errorLogger?(error)
+                }
+            }
         }
     }
 }
@@ -47,3 +73,43 @@ public extension UserDefault {
         self.init(key, default: `default`, userDefaults: userDefaults)
     }
 }
+
+/// Taken from: https://github.com/guillermomuntaner/Burritos/blob/master/Sources/UserDefault/UserDefault.swift
+/// A type than can be stored in `UserDefaults`.
+///
+/// - From UserDefaults;
+/// The value parameter can be only property list objects: NSData, NSString, NSNumber, NSDate, NSArray, or NSDictionary.
+/// For NSArray and NSDictionary objects, their contents must be property list objects. For more information, see What is a
+/// Property List? in Property List Programming Guide.
+public protocol PropertyListValue {}
+
+extension Data: PropertyListValue {}
+extension NSData: PropertyListValue {}
+
+extension String: PropertyListValue {}
+extension NSString: PropertyListValue {}
+
+extension Date: PropertyListValue {}
+extension NSDate: PropertyListValue {}
+
+extension NSNumber: PropertyListValue {}
+extension Bool: PropertyListValue {}
+extension Int: PropertyListValue {}
+extension Int8: PropertyListValue {}
+extension Int16: PropertyListValue {}
+extension Int32: PropertyListValue {}
+extension Int64: PropertyListValue {}
+extension UInt: PropertyListValue {}
+extension UInt8: PropertyListValue {}
+extension UInt16: PropertyListValue {}
+extension UInt32: PropertyListValue {}
+extension UInt64: PropertyListValue {}
+extension Double: PropertyListValue {}
+extension Float: PropertyListValue {}
+#if os(macOS)
+extension Float80: PropertyListValue {}
+#endif
+
+extension Array: PropertyListValue where Element: PropertyListValue {}
+
+extension Dictionary: PropertyListValue where Key == String, Value: PropertyListValue {}

--- a/ACKategoriesCoreTests/PropertyWrappers/UserDefaultTests.swift
+++ b/ACKategoriesCoreTests/PropertyWrappers/UserDefaultTests.swift
@@ -28,8 +28,19 @@ final class UserDefaultTests: XCTestCase {
         
         // Then
         XCTAssertTrue(subject.hasSeen)
-        let hasSeenData = try XCTUnwrap(userDefaults.object(forKey: "has_seen") as? Data)
-        XCTAssertEqual(try decoder.decode([Bool].self, from: hasSeenData), [true])
+        XCTAssertEqual(userDefaults.object(forKey: "has_seen") as? Bool, true)
+    }
+    
+    func testStringArrayValueChanges() throws {
+        // Given
+        let strings = ["ack", "kategories"]
+        
+        // When
+        subject.stringArray = strings
+        
+        // Then
+        XCTAssertEqual(subject.stringArray, strings)
+        XCTAssertEqual(userDefaults.object(forKey: "string_array") as? [String], strings)
     }
     
     func testSettingCodableValue() throws {
@@ -52,6 +63,9 @@ final class UserDefaultTests: XCTestCase {
 private struct MyUserDefaultProvider {
     @UserDefault("has_seen", default: false, userDefaults: UserDefaults(suiteName: "my_user_default")!)
     var hasSeen: Bool
+    
+    @UserDefault("string_array", default: [], userDefaults: UserDefaults(suiteName: "my_user_default")!)
+    var stringArray: [String]
     
     @UserDefault("codable_value", userDefaults: UserDefaults(suiteName: "my_user_default")!)
     var codableValue: CodableValue?

--- a/ACKategoriesCoreTests/PropertyWrappers/UserDefaultTests.swift
+++ b/ACKategoriesCoreTests/PropertyWrappers/UserDefaultTests.swift
@@ -29,7 +29,7 @@ final class UserDefaultTests: XCTestCase {
         // Then
         XCTAssertTrue(subject.hasSeen)
         let hasSeenData = try XCTUnwrap(userDefaults.object(forKey: "has_seen") as? Data)
-        XCTAssertEqual(try decoder.decode(Bool.self, from: hasSeenData), true)
+        XCTAssertEqual(try decoder.decode([Bool].self, from: hasSeenData), [true])
     }
     
     func testSettingCodableValue() throws {
@@ -45,7 +45,7 @@ final class UserDefaultTests: XCTestCase {
         // Then
         XCTAssertEqual(subject.codableValue, value)
         let data = try XCTUnwrap(userDefaults.object(forKey: "codable_value") as? Data)
-        XCTAssertEqual(try decoder.decode(CodableValue.self, from: data), value)
+        XCTAssertEqual(try decoder.decode([CodableValue].self, from: data), [value])
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Next
 
+### Fixed
+
+- Encoding of primitive values ([#90](https://github.com/AckeeCZ/ACKategories/pull/90), kudos to @fortmarek) 
+
 ## 6.6.0
 
 ### Added


### PR DESCRIPTION
Resolves https://github.com/AckeeCZ/ACKategories/issues/89

As we want to support pre-iOS versions and be compatible with current setting of user defaults, I have changed `UserDefault` implementation to use `userDefault.set/get` for supported values, for other `Codable` values we preserve the implementation with `JSONDecoder`

#### Checklist
- [x] Added tests
