### PR TITLE
Deprecate TableHeaderFooterView

### DIFF
--- a/ACKategories-iOS/SelfSizingTableHeaderFooterView.swift
+++ b/ACKategories-iOS/SelfSizingTableHeaderFooterView.swift
@@ -10,7 +10,7 @@ import UIKit
 /// This view will autolayout its height, even when used as a tableHeaderView or tableFooterView.
 open class SelfSizingTableHeaderFooterView: UITableViewHeaderFooterView {
 
-    fileprivate enum Status {
+    private enum Status {
         /// View is set as tableHeaderView
         case header
         /// View is set as tableFooterView
@@ -21,11 +21,11 @@ open class SelfSizingTableHeaderFooterView: UITableViewHeaderFooterView {
 
     // MARK: - Fileprivate properties
 
-    fileprivate var tableView: UITableView? {
+    private var tableView: UITableView? {
         return superview as? UITableView
     }
 
-    fileprivate var status: Status {
+    private var status: Status {
         return self == tableView?.tableHeaderView ? .header :
             self == tableView?.tableFooterView ? .footer :
             .none
@@ -55,7 +55,7 @@ open class SelfSizingTableHeaderFooterView: UITableViewHeaderFooterView {
 
     // MARK: - Helpers
 
-    fileprivate func fittingSize(for view: UIView) -> CGSize {
+    private func fittingSize(for view: UIView) -> CGSize {
         let targetSize = CGSize(
             width: view.frame.width,
             height: UIView.layoutFittingCompressedSize.height

--- a/ACKategories-iOS/SelfSizingTableHeaderFooterView.swift
+++ b/ACKategories-iOS/SelfSizingTableHeaderFooterView.swift
@@ -1,0 +1,70 @@
+//
+//  SelfSizingTableHeaderFooterView.swift
+//  ACKategories-iOS
+//
+//  Created by Karel Leinhäupl on 06.09.2020.
+//
+
+import UIKit
+
+/// This view will autolayout its height, even when used as a tableHeaderView or tableFooterView.
+open class SelfSizingTableHeaderFooterView: UITableViewHeaderFooterView {
+
+    fileprivate enum Status {
+        /// View is set as tableHeaderView
+        case header
+        /// View is set as tableFooterView
+        case footer
+        /// View is set as normal view elsewhere
+        case none
+    }
+
+    // MARK: - Fileprivate properties
+
+    fileprivate var tableView: UITableView? {
+        return superview as? UITableView
+    }
+
+    fileprivate var status: Status {
+        return self == tableView?.tableHeaderView ? .header :
+            self == tableView?.tableFooterView ? .footer :
+            .none
+    }
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard status != .none else { return }
+        let frameSize = fittingSize(for: self)
+        let contentViewSize = fittingSize(for: contentView)
+        frame = CGRect(
+            origin: frame.origin,
+            size: frameSize
+        )
+        contentView.frame = CGRect(
+            origin: contentView.frame.origin,
+            size: contentViewSize
+        )
+
+        switch status {
+        case .header: tableView?.tableHeaderView = self
+        case .footer: tableView?.tableFooterView = self
+        case .none: return
+        }
+    }
+
+    // MARK: - Helpers
+
+    fileprivate func fittingSize(for view: UIView) -> CGSize {
+        let targetSize = CGSize(
+            width: view.frame.width,
+            height: UIView.layoutFittingCompressedSize.height
+        )
+
+        return systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .defaultLow
+        )
+    }
+}

--- a/ACKategories-iOS/TableHeaderFooterView.swift
+++ b/ACKategories-iOS/TableHeaderFooterView.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 /// This view will autolayout its height, even when used as a tableHeaderView or tableFooterView.
+@available(*, deprecated, message: "Use SelfSizingTableHeaderFooterView instead. TableHeaderFooterView inherits from UIView and not UITableViewHeaderFooterView, its readableContentGuide behaves differently from UITableViewCells.")
 open class TableHeaderFooterView: UIView {
     fileprivate var tableView: UITableView? {
         return superview as? UITableView

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		69FA5FBC23C868A900B44BCD /* AppFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA5FAB23C868A900B44BCD /* AppFlowCoordinator.swift */; };
 		69FA5FBD23C868A900B44BCD /* ModalFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA5FAC23C868A900B44BCD /* ModalFlowCoordinator.swift */; };
 		69FA5FC223C8690A00B44BCD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 69FA5FC123C8690A00B44BCD /* LaunchScreen.storyboard */; };
+		6A31C9F3250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A31C9F2250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift */; };
 		F885BD98245AC4240071073D /* Date+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = F885BD95245AC4240071073D /* Date+Random.swift */; };
 		F885BD99245AC4240071073D /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = F885BD96245AC4240071073D /* String+Random.swift */; };
 		F885BD9A245AC4240071073D /* Int+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = F885BD97245AC4240071073D /* Int+Random.swift */; };
@@ -262,6 +263,7 @@
 		69FA5FC123C8690A00B44BCD /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		69FA5FC323C869A200B44BCD /* ACKategories.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = ACKategories.podspec; sourceTree = "<group>"; };
 		69FA5FE423C8712D00B44BCD /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		6A31C9F2250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingTableHeaderFooterView.swift; sourceTree = "<group>"; };
 		F885BD95245AC4240071073D /* Date+Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Random.swift"; sourceTree = "<group>"; };
 		F885BD96245AC4240071073D /* String+Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
 		F885BD97245AC4240071073D /* Int+Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+Random.swift"; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				6950964823C7751600E8F457 /* GradientView.swift */,
 				6950964D23C7752B00E8F457 /* NSMutableParagraphStyleExtensions.swift */,
 				6950965223C7753D00E8F457 /* ReusableView.swift */,
+				6A31C9F2250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift */,
 				6950966623C78AC800E8F457 /* TableHeaderFooterView.swift */,
 				6950966023C78AC800E8F457 /* UIApplicationExtensions.swift */,
 				6950966423C78AC800E8F457 /* UIButtonExtensions.swift */,
@@ -974,6 +977,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A31C9F3250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift in Sources */,
 				6950962F23C7747800E8F457 /* ViewController.swift in Sources */,
 				F8B81697246C59F7005D1D74 /* Int+Random.swift in Sources */,
 				6950964323C774DB00E8F457 /* DateExtensions.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Next
 
+- Deprecated `TableHeaderFooterView` because of different `readableContentGuide` behavior ([#92](https://github.com/AckeeCZ/ACKategories/pull/92), kudos to @leinhauplk)
+
 ### Fixed
 
 - Encoding of primitive values ([#90](https://github.com/AckeeCZ/ACKategories/pull/90), kudos to @fortmarek) 


### PR DESCRIPTION
Resolves: https://github.com/AckeeCZ/ACKategories/issues/91

#### Checklist
- [ ] Added tests (if applicable)

#### Summary
- Deprecate TableHeaderFooterView
- Introduce SelfSizingTableHeaderFooterView which inherits from UITableViewHeaderFooterView
