### PR TITLE
🐛 Fix optional `presentingController` in `stop` method

### DIFF
--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -116,10 +116,10 @@ extension Base {
             // as presentingVC of root when modally presenting can be UITabBarController,
             // but the whole navigation shouldn't be dismissed, as there are still VCs
             // remaining in the navigation stack
-            if shouldCallDismissOnPresentingVC {
+            if shouldCallDismissOnPresentingVC, let presentingViewController = rootViewController.presentingViewController {
                 // dismiss when root was presented
                 animationGroup.enter()
-                rootViewController.presentingViewController?.dismiss(animated: animated, completion: animationGroup.leave)
+                presentingViewController.dismiss(animated: animated, completion: animationGroup.leave)
             }
 
             // stopping FC doesn't need to be nav delegate anymore -> pass it to parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Encoding of primitive values ([#90](https://github.com/AckeeCZ/ACKategories/pull/90), kudos to @fortmarek) 
+- `completion` of `Base.FlowCoordinator.stop()` is sometimes not called ([#94](https://github.com/AckeeCZ/ACKategories/pull/94), kudos to @lukashromadnik)
 
 ## 6.6.0
 


### PR DESCRIPTION
Fixes a possible problem where the `completion` block is not called because of unbalanced `group.enter()` and `group.leave()` calls
