### PR TITLE
Update iOS deployment target

### DIFF
--- a/ACKategories.podspec
+++ b/ACKategories.podspec
@@ -12,7 +12,7 @@ Tools, cocoa subclasses and extensions we love to use at Ackee.
   s.social_media_url = 'https://twitter.com/ackeecz'
   s.swift_version    = '5.1.3'
   
-  s.ios.deployment_target = '8.3'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.9'
   
   s.source_files     = 'ACKategoriesCore/**/*.swift'

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -740,7 +740,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1220;
 				TargetAttributes = {
 					695096D723C7908B00E8F457 = {
 						CreatedOnToolsVersion = 11.3;
@@ -1228,6 +1228,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1262,6 +1263,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1275,6 +1277,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1629,7 +1632,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "ACKategories-iOS/Supporting files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1705,7 +1708,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "ACKategories-iOS/Supporting files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1876,6 +1879,7 @@
 		69EB1E9E2498CDE900AF815F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1884,6 +1888,7 @@
 		69EB1E9F2498CDE900AF815F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategories-iOS.xcscheme
+++ b/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategories-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategoriesCore.xcscheme
+++ b/ACKategories.xcodeproj/xcshareddata/xcschemes/ACKategoriesCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Next
 
 - Deprecated `TableHeaderFooterView` because of different `readableContentGuide` behavior ([#92](https://github.com/AckeeCZ/ACKategories/pull/92), kudos to @leinhauplk)
+- Updated iOS deployment target to **9.0** to make Xcode 12 happy ([#95](https://github.com/AckeeCZ/ACKategories/pull/92), kudos to @olejnjak)
 
 ### Fixed
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ACKategories",
     platforms: [
-        .iOS("8.3"),
+        .iOS(.v9),
         .macOS("10.9")
     ],
     products: [


### PR DESCRIPTION
Update iOS deployment target so Xcode 12 is not complaining about importing dependency which has unsupported deployment target.