### PR TITLE
🐛 Make sure that rootViewController is not deallocated

### DIFF
--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -80,45 +80,48 @@ extension Base {
                 animationGroup.enter()
                 $0.stop(animated: animated, completion: animationGroup.leave)
             }
-
-            // dismiss all VCs presented from root or nav
-            if rootViewController.presentedViewController != nil {
-                animationGroup.enter()
-                rootViewController.dismiss(animated: animated, completion: animationGroup.leave)
-            }
-
-            // pop all view controllers when started within navigation controller
-            if let navigationController = navigationController, let index = navigationController.viewControllers.firstIndex(of: rootViewController) {
-                // VCs to be removed from navigation stack
-                let toRemoveViewControllers = navigationController.viewControllers[index..<navigationController.viewControllers.count]
-
-                // dismiss all presented VCs on VCs to be removed
-                toRemoveViewControllers.forEach { vc in
-                    if vc.presentedViewController != nil {
-                        animationGroup.enter()
-                        vc.dismiss(animated: animated, completion: animationGroup.leave)
+            
+            if let rootViewController = rootViewController {
+                
+                // dismiss all VCs presented from root or nav
+                if rootViewController.presentedViewController != nil {
+                    animationGroup.enter()
+                    rootViewController.dismiss(animated: animated, completion: animationGroup.leave)
+                }
+                
+                // pop all view controllers when started within navigation controller
+                if let navigationController = navigationController, let index = navigationController.viewControllers.firstIndex(of: rootViewController) {
+                    // VCs to be removed from navigation stack
+                    let toRemoveViewControllers = navigationController.viewControllers[index..<navigationController.viewControllers.count]
+                    
+                    // dismiss all presented VCs on VCs to be removed
+                    toRemoveViewControllers.forEach { vc in
+                        if vc.presentedViewController != nil {
+                            animationGroup.enter()
+                            vc.dismiss(animated: animated, completion: animationGroup.leave)
+                        }
                     }
+                    
+                    // VCs to remain in the navigation stack
+                    let remainingViewControllers = Array(navigationController.viewControllers[0..<index])
+                    
+                    if remainingViewControllers.isNotEmpty {
+                        navigationController.setViewControllers(remainingViewControllers, animated: animated)
+                    }
+                    
+                    // set the appropriate value based on whether there are VCs remaining in the navigation stack
+                    shouldCallDismissOnPresentingVC = remainingViewControllers.isEmpty
                 }
-
-                // VCs to remain in the navigation stack
-                let remainingViewControllers = Array(navigationController.viewControllers[0..<index])
-
-                if remainingViewControllers.isNotEmpty {
-                    navigationController.setViewControllers(remainingViewControllers, animated: animated)
+                
+                // ensure that dismiss will be called on presentingVC of root only when appropriate,
+                // as presentingVC of root when modally presenting can be UITabBarController,
+                // but the whole navigation shouldn't be dismissed, as there are still VCs
+                // remaining in the navigation stack
+                if shouldCallDismissOnPresentingVC, let presentingViewController = rootViewController.presentingViewController {
+                    // dismiss when root was presented
+                    animationGroup.enter()
+                    presentingViewController.dismiss(animated: animated, completion: animationGroup.leave)
                 }
-
-                // set the appropriate value based on whether there are VCs remaining in the navigation stack
-                shouldCallDismissOnPresentingVC = remainingViewControllers.isEmpty
-            }
-
-            // ensure that dismiss will be called on presentingVC of root only when appropriate,
-            // as presentingVC of root when modally presenting can be UITabBarController,
-            // but the whole navigation shouldn't be dismissed, as there are still VCs
-            // remaining in the navigation stack
-            if shouldCallDismissOnPresentingVC, let presentingViewController = rootViewController.presentingViewController {
-                // dismiss when root was presented
-                animationGroup.enter()
-                presentingViewController.dismiss(animated: animated, completion: animationGroup.leave)
             }
 
             // stopping FC doesn't need to be nav delegate anymore -> pass it to parent

--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -76,13 +76,13 @@ extension Base {
                 animationGroup.enter()
                 $0.stop(animated: animated, completion: animationGroup.leave)
             }
-            
+
             dismissPresentedViewControllerIfPossible(animated: animated, group: animationGroup)
-            
+
             /// Determines whether dismiss should be called on `presentingViewController` of root,
             /// based on whether there are remaining VCs in the navigation stack.
             let shouldCallDismissOnPresentingVC = popAllViewControllersIfPossible(animated: animated, group: animationGroup)
-                
+
             // ensure that dismiss will be called on presentingVC of root only when appropriate,
             // as presentingVC of root when modally presenting can be UITabBarController,
             // but the whole navigation shouldn't be dismissed, as there are still VCs
@@ -102,9 +102,9 @@ extension Base {
                 completion?()
             }
         }
-        
+
         // MARK: - Stop helpers
-        
+
         /// Dismiss all VCs presented from root or nav if possible
         private func dismissPresentedViewControllerIfPossible(animated: Bool, group: DispatchGroup) {
             if let rootViewController = rootViewController, rootViewController.presentedViewController != nil {
@@ -112,7 +112,7 @@ extension Base {
                 rootViewController.dismiss(animated: animated, completion: group.leave)
             }
         }
-    
+
         /// Pop all view controllers when started within navigation controller
         /// - Returns: Flag whether dismiss should be called on `presentingViewController` of root,
         /// based on whether there are remaining VCs in the navigation stack.
@@ -124,7 +124,7 @@ extension Base {
             {
                 // VCs to be removed from navigation stack
                 let toRemoveViewControllers = navigationController.viewControllers[index..<navigationController.viewControllers.count]
-                
+
                 // dismiss all presented VCs on VCs to be removed
                 toRemoveViewControllers.forEach { vc in
                     if vc.presentedViewController != nil {
@@ -132,22 +132,21 @@ extension Base {
                         vc.dismiss(animated: animated, completion: group.leave)
                     }
                 }
-                
+
                 // VCs to remain in the navigation stack
                 let remainingViewControllers = Array(navigationController.viewControllers[0..<index])
-                
+
                 if remainingViewControllers.isNotEmpty {
                     navigationController.setViewControllers(remainingViewControllers, animated: animated)
                 }
-                
+
                 // set the appropriate value based on whether there are VCs remaining in the navigation stack
                 return remainingViewControllers.isEmpty
             }
-            
+
             // Return the default value for the flag
             return true
         }
-        
 
         // MARK: - Child coordinators
 

--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -77,6 +77,10 @@ extension Base {
                 $0.stop(animated: animated, completion: animationGroup.leave)
             }
 
+            if rootViewController == nil {
+                ErrorHandlers.rootViewControllerDeallocatedBeforeStop?()
+            }
+
             dismissPresentedViewControllerIfPossible(animated: animated, group: animationGroup)
 
             /// Determines whether dismiss should be called on `presentingViewController` of root,

--- a/ACKategories-iOS/ErrorHandlers.swift
+++ b/ACKategories-iOS/ErrorHandlers.swift
@@ -1,0 +1,16 @@
+//
+//  ErrorHandlers.swift
+//  ACKategories-iOS
+//
+//  Created by Lukáš Hromadník on 07.12.2020.
+//
+
+import Foundation
+
+/// Set of handlers for some undefined behaviors in the framework
+public enum ErrorHandlers {
+    
+    /// Called when `rootViewController` of the respective flow coordinator
+    /// is deallocated before the actual stop method logic is called
+    public static var rootViewControllerDeallocatedBeforeStop: (() -> Void)?
+}

--- a/ACKategories-iOS/ErrorHandlers.swift
+++ b/ACKategories-iOS/ErrorHandlers.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Set of handlers for some undefined behaviors in the framework
 public enum ErrorHandlers {
-    
+
     /// Called when `rootViewController` of the respective flow coordinator
     /// is deallocated before the actual stop method logic is called
     public static var rootViewControllerDeallocatedBeforeStop: (() -> Void)?

--- a/ACKategories-iOSTests/FlowCoordinator/FlowCoordinatorTests.swift
+++ b/ACKategories-iOSTests/FlowCoordinator/FlowCoordinatorTests.swift
@@ -188,4 +188,15 @@ final class FlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssertEqual(fc.childCoordinators.count, 0)
     }
+    
+    func testRootViewControllerIsNil() {
+        let fc = NavigationFC()
+        fc.start(in: window)
+        _ = fc.rootViewController.view
+        fc.rootViewController = nil
+        
+        let exp = expectation(description: "Flow did finish")
+        fc.stop(animated: false) { exp.fulfill() }
+        wait(for: [exp], timeout: 0.3)
+    }
 }

--- a/ACKategories-iOSTests/FlowCoordinator/FlowCoordinatorTests.swift
+++ b/ACKategories-iOSTests/FlowCoordinator/FlowCoordinatorTests.swift
@@ -16,6 +16,8 @@ final class FlowCoordinatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
+        ErrorHandlers.rootViewControllerDeallocatedBeforeStop = nil
+        
         window = .dummy
     }
     
@@ -198,5 +200,19 @@ final class FlowCoordinatorTests: XCTestCase {
         let exp = expectation(description: "Flow did finish")
         fc.stop(animated: false) { exp.fulfill() }
         wait(for: [exp], timeout: 0.3)
+    }
+    
+    func testErrorCallbackIsCalled() {
+        let rootExp = expectation(description: "Root is deallocated")
+        ErrorHandlers.rootViewControllerDeallocatedBeforeStop = { rootExp.fulfill() }
+        
+        let fc = NavigationFC()
+        fc.start(in: window)
+        _ = fc.rootViewController.view
+        fc.rootViewController = nil
+        
+        let exp = expectation(description: "Flow did finish")
+        fc.stop(animated: false) { exp.fulfill() }
+        wait(for: [exp, rootExp], timeout: 0.3)
     }
 }

--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		69FA5FC223C8690A00B44BCD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 69FA5FC123C8690A00B44BCD /* LaunchScreen.storyboard */; };
 		6A31C9F3250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A31C9F2250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift */; };
 		A33559012555270F009B9D89 /* FlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33559002555270F009B9D89 /* FlowCoordinatorTests.swift */; };
+		A38883E3257E2D2D00B958DD /* ErrorHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38883E2257E2D2D00B958DD /* ErrorHandlers.swift */; };
 		A3BA685B256BEC7B006DB42F /* UIWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA685A256BEC7B006DB42F /* UIWindow.swift */; };
 		A3BA6867256BECC6006DB42F /* UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA6866256BECC6006DB42F /* UINavigationController.swift */; };
 		A3BA686E256BED96006DB42F /* Dummies.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA686D256BED96006DB42F /* Dummies.swift */; };
@@ -266,6 +267,7 @@
 		69FA5FE423C8712D00B44BCD /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		6A31C9F2250572FE0047A983 /* SelfSizingTableHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingTableHeaderFooterView.swift; sourceTree = "<group>"; };
 		A33559002555270F009B9D89 /* FlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCoordinatorTests.swift; sourceTree = "<group>"; };
+		A38883E2257E2D2D00B958DD /* ErrorHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlers.swift; sourceTree = "<group>"; };
 		A3BA685A256BEC7B006DB42F /* UIWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindow.swift; sourceTree = "<group>"; };
 		A3BA6866256BECC6006DB42F /* UINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationController.swift; sourceTree = "<group>"; };
 		A3BA686D256BED96006DB42F /* Dummies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dummies.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 			children = (
 				6950963023C7747C00E8F457 /* Base */,
 				697CECF023C877B20019FE61 /* Aliases.swift */,
+				A38883E2257E2D2D00B958DD /* ErrorHandlers.swift */,
 				6950964823C7751600E8F457 /* GradientView.swift */,
 				6950964D23C7752B00E8F457 /* NSMutableParagraphStyleExtensions.swift */,
 				6950965223C7753D00E8F457 /* ReusableView.swift */,
@@ -995,6 +998,7 @@
 				6950965123C7753500E8F457 /* NumberFormatterExtensions.swift in Sources */,
 				6950964523C774DB00E8F457 /* ConditionalAssignment.swift in Sources */,
 				6950962823C7740B00E8F457 /* Base.swift in Sources */,
+				A38883E3257E2D2D00B958DD /* ErrorHandlers.swift in Sources */,
 				6950964C23C7751E00E8F457 /* NSAttributedStringExtensions.swift in Sources */,
 				6950967123C78AC900E8F457 /* UILabelExtensions.swift in Sources */,
 				F8B81694246C59F7005D1D74 /* Date+Random.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Next
 
+- Check the value of `rootViewController` before stopping the flow ([#98](https://github.com/AckeeCZ/ACKategories/pull/98), kudos to @lukashromadnik)
+
 ## 6.7.2
 
 ### Fixed


### PR DESCRIPTION
We have a strange crash in Bazos where `rootViewController` is deallocated before the flow is stopped. Since the `rootViewController` is implicitly unwrapped and since we have no idea how to properly reproduce the crash this is the simplest solution to our problem.

I think that we have some specific bug in Bazos and this shouldn't be necessary but right now it's the only way.

#### Checklist
- [x] Added tests (if applicable)
