### PR TITLE
Disable user interaction on GradientView

### DIFF
--- a/ACKategories-iOS/GradientView.swift
+++ b/ACKategories-iOS/GradientView.swift
@@ -15,12 +15,7 @@ import UIKit
     `[UIColor.white, UIColor.white.withAlphaComponent(0)]`
  */
 open class GradientView: UIView {
-
-    override open class var layerClass: Swift.AnyClass {
-        get {
-            return CAGradientLayer.self
-        }
-    }
+    override open class var layerClass: Swift.AnyClass { CAGradientLayer.self }
 
     /**
      Creates a gradient view with colors and axis
@@ -30,9 +25,14 @@ open class GradientView: UIView {
      */
     public init(colors: [UIColor], axis: NSLayoutConstraint.Axis) {
         super.init(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+
         guard let gradientLayer = layer as? CAGradientLayer else { return }
+        
+        isUserInteractionEnabled = false
+
         gradientLayer.frame = bounds
         gradientLayer.colors = colors.map { $0.cgColor }
+
         if axis == .vertical {
             gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
             gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)

--- a/ACKategories-iOS/GradientView.swift
+++ b/ACKategories-iOS/GradientView.swift
@@ -27,7 +27,7 @@ open class GradientView: UIView {
         super.init(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
 
         guard let gradientLayer = layer as? CAGradientLayer else { return }
-        
+
         isUserInteractionEnabled = false
 
         gradientLayer.frame = bounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Next
 
+### Fixed
+
+- `GradientView` has `isUserInteractionEnabled = false` as it is not supposed to be interactive by design ([#99](https://github.com/AckeeCZ/ACKategories/pull/99), kudos to @olejnjak)
+
 ## 6.7.2
 
 ### Fixed


### PR DESCRIPTION
`GradientView` should be consider non-interactive just as `UIImageView` is, so it should have `isUserInteractionEnabled = false`.

Resolves #93.