### PR TITLE
🐛 Fix navigation controller's delegate on flow coordinator that is navigation root

### DIFF
--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -149,8 +149,16 @@ extension Base {
         // MARK: - UINavigationControllerDelegate
 
         public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+            // Check if the root is not dead
             guard let rootViewController = rootViewController else { return }
+
+            // If the navigation controller is the current root view controller
+            // then this method shouldn't get called.
+            // But that's not possible with our current implementation.
             guard self.navigationController != rootViewController else { return }
+
+            // If `rootViewController` is not presented in the navigation stack
+            // we have to stop the current flow
             if !navigationController.viewControllers.contains(rootViewController) {
                 navigationController.delegate = parentCoordinator
                 stop()

--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -157,7 +157,7 @@ extension Base {
             // But that's not possible with our current implementation.
             guard self.navigationController != rootViewController else { return }
 
-            // If `rootViewController` is not presented in the navigation stack
+            // If `rootViewController` is not present in the navigation stack
             // we have to stop the current flow
             if !navigationController.viewControllers.contains(rootViewController) {
                 navigationController.delegate = parentCoordinator

--- a/ACKategories-iOS/Base/FlowCoordinator.swift
+++ b/ACKategories-iOS/Base/FlowCoordinator.swift
@@ -149,7 +149,9 @@ extension Base {
         // MARK: - UINavigationControllerDelegate
 
         public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-            if let rootViewController = rootViewController, !navigationController.viewControllers.contains(rootViewController) {
+            guard let rootViewController = rootViewController else { return }
+            guard self.navigationController != rootViewController else { return }
+            if !navigationController.viewControllers.contains(rootViewController) {
                 navigationController.delegate = parentCoordinator
                 stop()
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Next
 
+### Fixed
+
+- Check if `navigationController != rootViewController` before running navigation delegate method ([#100](https://github.com/AckeeCZ/ACKategories/pull/100), kudos to @lukashromadnik)
+
 ## 6.7.2
 
 ### Fixed


### PR DESCRIPTION
Our current implementation has a problem where dying child coordinator that was `navigationController?.delegate` passes this responsibility to its parent. But if the parent has `navigationController == rootViewController` then the delegate method will also stop the parent flow. This behavior is caused by the previous fix. 😔

Currently we are not able to resolve this issue with better fix than checking if the `navigationController != rootViewController`

#### Checklist
- [x] Added tests (if applicable)
