### PR TITLE
Safe `Double` to `Int`

### DIFF
--- a/ACKategories.xcodeproj/project.pbxproj
+++ b/ACKategories.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		6914B1142728231300FF177E /* TagListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6914B1132728231300FF177E /* TagListView.swift */; };
+		6922A08B273B2630004B2B1F /* IntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6922A08A273B2630004B2B1F /* IntTests.swift */; };
 		69372705257FAF02007CE25C /* UINavigationControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69372704257FAF02007CE25C /* UINavigationControllerExtensions.swift */; };
 		69372720257FB0A3007CE25C /* UINavigationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6937271F257FB0A3007CE25C /* UINavigationControllerTests.swift */; };
 		6950962523C7740B00E8F457 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6950962223C7740A00E8F457 /* ViewModel.swift */; };
@@ -92,6 +93,7 @@
 		69E819FB23C773240054687B /* ACKategoriesCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E819ED23C773240054687B /* ACKategoriesCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69E81A1023C773370054687B /* ACKategories.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69E81A0723C773370054687B /* ACKategories.framework */; platformFilter = ios; };
 		69E81A1723C773370054687B /* ACKategories_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E81A0923C773370054687B /* ACKategories_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69F7058E273ADBA3004DD190 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F7058D273ADBA3004DD190 /* IntExtensions.swift */; };
 		69FA5FAD23C868A900B44BCD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69FA5F9023C868A900B44BCD /* Assets.xcassets */; };
 		69FA5FAE23C868A900B44BCD /* UIControlBlocksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA5F9323C868A900B44BCD /* UIControlBlocksViewController.swift */; };
 		69FA5FAF23C868A900B44BCD /* TitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA5F9523C868A900B44BCD /* TitleViewController.swift */; };
@@ -191,6 +193,7 @@
 
 /* Begin PBXFileReference section */
 		6914B1132728231300FF177E /* TagListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListView.swift; sourceTree = "<group>"; };
+		6922A08A273B2630004B2B1F /* IntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntTests.swift; sourceTree = "<group>"; };
 		69372704257FAF02007CE25C /* UINavigationControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtensions.swift; sourceTree = "<group>"; };
 		6937271F257FB0A3007CE25C /* UINavigationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerTests.swift; sourceTree = "<group>"; };
 		6950962223C7740A00E8F457 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
@@ -252,6 +255,7 @@
 		69E81A0A23C773370054687B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		69E81A0F23C773370054687B /* ACKategories-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ACKategories-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		69E81A1623C773370054687B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		69F7058D273ADBA3004DD190 /* IntExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntExtensions.swift; sourceTree = "<group>"; };
 		69FA5F9023C868A900B44BCD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		69FA5F9323C868A900B44BCD /* UIControlBlocksViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControlBlocksViewController.swift; sourceTree = "<group>"; };
 		69FA5F9523C868A900B44BCD /* TitleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleViewController.swift; sourceTree = "<group>"; };
@@ -421,6 +425,7 @@
 				6950963923C774DB00E8F457 /* DateExtensions.swift */,
 				6950963823C774DB00E8F457 /* DateFormatting.swift */,
 				6950963623C774DB00E8F457 /* DictionaryExtensions.swift */,
+				69F7058D273ADBA3004DD190 /* IntExtensions.swift */,
 				6950964A23C7751E00E8F457 /* NSAttributedStringExtensions.swift */,
 				6950964F23C7753500E8F457 /* NumberFormatterExtensions.swift */,
 				6950965523C7754D00E8F457 /* Reusable.swift */,
@@ -441,6 +446,7 @@
 				6950968E23C78CC200E8F457 /* ConditionalAssignmentTests.swift */,
 				6950969523C78CC200E8F457 /* DateFormattingTests.swift */,
 				6950969223C78CC200E8F457 /* FoundationTests.swift */,
+				6922A08A273B2630004B2B1F /* IntTests.swift */,
 				6950969623C78CC200E8F457 /* StringTests.swift */,
 				69E819FA23C773240054687B /* Info.plist */,
 			);
@@ -953,6 +959,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				69F7058E273ADBA3004DD190 /* IntExtensions.swift in Sources */,
 				F885BDA3245ACD010071073D /* Randomizable.swift in Sources */,
 				6950964423C774DB00E8F457 /* ConditionalAssignment.swift in Sources */,
 				6950963C23C774DB00E8F457 /* DictionaryExtensions.swift in Sources */,
@@ -980,6 +987,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6922A08B273B2630004B2B1F /* IntTests.swift in Sources */,
 				695096B123C78E2200E8F457 /* DateFormattingTests.swift in Sources */,
 				F885BD9F245AC43A0071073D /* DateRandomTests.swift in Sources */,
 				695096AE23C78E2200E8F457 /* ArrayTests.swift in Sources */,

--- a/ACKategoriesCore/IntExtensions.swift
+++ b/ACKategoriesCore/IntExtensions.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public extension Int {
+    /// Optionally create `Int` checking if `double` is not Nan nor infinity
+    init?(safe double: Double) {
+        if double.isNaN || double.isInfinite {
+            return nil
+        }
+        
+        self.init(double)
+    }
+    
+    /// Optionally create `Int` checking if `float` is not Nan nor infinity
+    init?(safe float: Float) {
+        if float.isNaN || float.isInfinite {
+            return nil
+        }
+        
+        self.init(float)
+    }
+    
+    /// Optionally create `Int` checking if `cgFloat` is not Nan nor infinity
+    init?(safe cgFloat: CGFloat) {
+        if cgFloat.isNaN || cgFloat.isInfinite {
+            return nil
+        }
+        
+        self.init(cgFloat)
+    }
+}

--- a/ACKategoriesCoreTests/IntTests.swift
+++ b/ACKategoriesCoreTests/IntTests.swift
@@ -1,0 +1,46 @@
+import ACKategoriesCore
+import XCTest
+
+final class IntTests: XCTestCase {
+    func test_safeInit_doubleNAN() {
+        XCTAssertNil(Int(safe: Double.nan))
+    }
+    
+    func test_safeInit_floatNAN() {
+        XCTAssertNil(Int(safe: Float.nan))
+    }
+    
+    func test_safeInit_cgFloatNAN() {
+        XCTAssertNil(Int(safe: CGFloat.nan))
+    }
+    
+    func test_safeInit_doubleInfinity() {
+        XCTAssertNil(Int(safe: Double.infinity))
+    }
+    
+    func test_safeInit_floatInfinity() {
+        XCTAssertNil(Int(safe: Float.infinity))
+    }
+    
+    func test_safeInit_cgFloatInfinity() {
+        XCTAssertNil(Int(safe: CGFloat.infinity))
+    }
+    
+    func test_safeInit_doubleValid() {
+        let value = Double.random(in: -1000...1000)
+        
+        XCTAssertEqual(Int(value), Int(safe: value))
+    }
+    
+    func test_safeInit_floatValid() {
+        let value = Float.random(in: -1000...1000)
+        
+        XCTAssertEqual(Int(value), Int(safe: value))
+    }
+    
+    func test_safeInit_cgFloatValid() {
+        let value = CGFloat.random(in: -1000...1000)
+        
+        XCTAssertEqual(Int(value), Int(safe: value))
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Next
 
+- Add `Int` inits that safely convert given floating value (`Double`, `Float`, `CGFloat`) to `Int` by checking for `NaN` and `infinity` ([#110](https://github.com/AckeeCZ/ACKategories/pull/110), kudos to @olejnjak)
+
 ## 6.9.0
 
 - Add `TagListView` ([#107](https://github.com/AckeeCZ/ACKategories/pull/107), kudos to @olejnjak)


### PR DESCRIPTION
Add `Int` extensions, that allow safe conversion of floating types to `Int` so conversion doesn't crash.

#### Checklist
- [x] Added tests (if applicable)
