### PR TITLE
Introduce `parentNavigationDelegate` in `FlowCoordinator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ```
 
 ## Next
+- Fix navigation stack when managed by flow coordinators in non-linear hierarchy ([#123](https://github.com/AckeeCZ/ACKategories/pull/123), kudos to @olejnjak)
 - Add custom `ZipMany` publisher. ([#116](https://github.com/AckeeCZ/ACKategories/pull/116), kudos to @vendulasvastal)
 
 ## 6.11.1


### PR DESCRIPTION
When multiple flow coordinators manage shared navigation stack, they should be chained propertly
```
ParentFlow -> ChildFlow1 -> ChildFlow2
```
But this is not always easy to achieve, sometimes you end up with hierarchy like this
```
ParentFlow -> ChildFlow1
           -> ChildFlow2
```
This property is set in `start(with navigationController)`
so it can be used later in `stop` and in `UINavigationControllerDelegate` implementation

Currently a draft as I want to test it on some projects first.